### PR TITLE
Add skip-push option to action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,8 @@
-name: 'Bit Tag and Export'
-description: 'Persist Bit Soft Tags and Export to Remote Scope'
-branding: 
-  icon: 'upload-cloud'
-  color: 'purple'
+name: "Bit Tag and Export"
+description: "Persist Bit Soft Tags and Export to Remote Scope"
+branding:
+  icon: "upload-cloud"
+  color: "purple"
 inputs:
   ws-dir:
     description: "Workspace json file directory path"
@@ -30,6 +30,9 @@ inputs:
   increment-by:
     description: "Increment by"
     required: false
+  skip-push:
+    description: "Skip pushing the changes to the remote repository (useful when CI handles the push separately)"
+    required: false
 runs:
-  using: 'node20'
-  main: 'dist/index.js'
+  using: "node20"
+  main: "dist/index.js"

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: 'Bit Tag and Export'
 description: 'Persist Bit Soft Tags and Export to Remote Scope'
-branding:
+branding: 
   icon: 'upload-cloud'
   color: 'purple'
 inputs:

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,8 @@
-name: "Bit Tag and Export"
-description: "Persist Bit Soft Tags and Export to Remote Scope"
+name: 'Bit Tag and Export'
+description: 'Persist Bit Soft Tags and Export to Remote Scope'
 branding:
-  icon: "upload-cloud"
-  color: "purple"
+  icon: 'upload-cloud'
+  color: 'purple'
 inputs:
   ws-dir:
     description: "Workspace json file directory path"
@@ -31,8 +31,8 @@ inputs:
     description: "Increment by"
     required: false
   skip-push:
-    description: "Skip pushing the changes to the remote repository (useful when CI handles the push separately)"
+    description: 'Skip pushing the changes to the remote repository (useful when CI handles the push separately)'
     required: false
 runs:
-  using: "node20"
-  main: "dist/index.js"
+  using: 'node20'
+  main: 'dist/index.js'

--- a/index.ts
+++ b/index.ts
@@ -9,12 +9,13 @@ try {
   const prereleaseId: string = core.getInput("prerelease-id");
   const incrementBy: number = parseInt(core.getInput("increment-by"));
   const strict: boolean = core.getInput("strict") === "true" ? true : false;
+  const skipPush: boolean = core.getInput("skip-push") === "true" ? true : false;
 
   if (!githubToken) {
     throw new Error("GitHub token not found");
   }
 
-  run(githubToken, wsDir, build, increment, prereleaseId, incrementBy, strict);
+  run(githubToken, wsDir, build, increment, prereleaseId, incrementBy, strict, skipPush);
 } catch (error) {
   core.setFailed((error as Error).message);
 }

--- a/scripts/tag-export.ts
+++ b/scripts/tag-export.ts
@@ -1,10 +1,10 @@
-import * as core from "@actions/core";
 import { exec, getExecOutput } from "@actions/exec";
 import { context, getOctokit } from "@actions/github";
-import fs from "node:fs/promises";
-import { tmpdir } from "node:os";
-import path from "node:path";
+import * as core from "@actions/core";
 import semver from "semver";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { tmpdir } from "node:os";
 
 const getLastMergedPullRequest = async (
   octokit: any,

--- a/scripts/tag-export.ts
+++ b/scripts/tag-export.ts
@@ -1,10 +1,10 @@
+import * as core from "@actions/core";
 import { exec, getExecOutput } from "@actions/exec";
 import { context, getOctokit } from "@actions/github";
-import * as core from "@actions/core";
-import semver from "semver";
 import fs from "node:fs/promises";
-import path from "node:path";
 import { tmpdir } from "node:os";
+import path from "node:path";
+import semver from "semver";
 
 const getLastMergedPullRequest = async (
   octokit: any,
@@ -75,7 +75,7 @@ function getOverridenVersions(labels?: any[]): string[] {
     });
 }
 
-const run = async (githubToken: string, wsdir: string, build: boolean, increment: string, prereleaseId: string, incrementBy: number, strict: boolean) => {
+const run = async (githubToken: string, wsdir: string, build: boolean, increment: string, prereleaseId: string, incrementBy: number, strict: boolean, skipPush: boolean) => {
   const version = await getExecOutput("bit -v", [], { cwd: wsdir });
 
   // If the version is lower than 1.12.45, throw an error recommending to downgrade the action version to v2
@@ -117,6 +117,10 @@ const run = async (githubToken: string, wsdir: string, build: boolean, increment
 
   if (strict) {
     mergeArgs.push("--strict");
+  }
+
+  if (skipPush) {
+    mergeArgs.push("--skip-push");
   }
 
   if (globalVersion) {


### PR DESCRIPTION
In our workflow the main branch is write protected, so we have a separate step after exporting that creates a PR and merges it, instead of the action committing and pushing automatically.

The default of pushing is breaking our build after upgrading to version 4 of the `bit-tasks/tag-export`

This PR aims to solve that by allowing users to specify `skip-push` on the action.